### PR TITLE
Validation problem for /modify

### DIFF
--- a/server.js
+++ b/server.js
@@ -179,7 +179,7 @@ async function modifySubscriptionPage(req, res, next) {
         headers: senderApiHeaders
     }).then(response => response.json());
 
-    if (!subscriber.success) {
+    if (!subscriber.data) {
         res.status(401).send("Subscriber does not exist or hash key does not match.");
         return;
     }


### PR DESCRIPTION
There's no "success": "true" when there's actually data, only "success": "false" where there isn't.

Cool.